### PR TITLE
Add model that combines Prophet and Box-Cox transform

### DIFF
--- a/src/forecastga/models/prophet-boxcox.py
+++ b/src/forecastga/models/prophet-boxcox.py
@@ -12,7 +12,7 @@ from scipy.special import inv_boxcox
 from forecastga.models.base import BaseModel
 
 
-class Prophet_Model(BaseModel):
+class Prophet_BoxCox_Model(BaseModel):
     """Prophet Model Class"""
 
     def __init__(self, config):

--- a/src/forecastga/models/prophet-boxcox.py
+++ b/src/forecastga/models/prophet-boxcox.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python
+# coding: utf-8
+#
+
+"""ForecastGA: Prophet Model with Box-Cox transform of the data"""
+
+import pandas as pd
+from fbprophet import Prophet
+from scipy.stats import boxcox
+from scipy.special import inv_boxcox
+
+from forecastga.models.base import BaseModel
+
+
+class Prophet_Model(BaseModel):
+    """Prophet Model Class"""
+
+    def __init__(self, config):
+        super().__init__(config)
+
+    def train(self, **kwargs):
+
+        country_holidays = kwargs.get("country_holidays", "US")
+
+        if self.freq == "D":
+            ptm = Prophet(weekly_seasonality=True)
+        else:
+            ptm = Prophet()
+
+        ptm.add_country_holidays(country_name=country_holidays)
+
+        formatted_data = self.format_input(self.train_df)
+        transformed_y, self.lam = boxcox(formatted_data["y"]+1)
+        formatted_data["y"] = transformed_y
+
+        self.model = ptm.fit(formatted_data)
+
+    def forecast(self):
+        future = self.model.make_future_dataframe(
+            periods=self.forecast_len, freq=self.freq
+        )
+        future_pred = self.model.predict(future)
+        future_pred = future_pred[-self.forecast_len :]
+        future_pred["yhat"] = inv_boxcox(future_pred["yhat"], self.lam) - 1
+        self.prediction = self.format_output(future_pred)
+
+    @staticmethod
+    def format_input(df):
+        df_pr = df.reset_index()
+        df_pr.columns = ["ds", "y"]
+        return df_pr
+
+    @staticmethod
+    def format_output(df):
+        prophet_pred = pd.DataFrame({"Date": df["ds"], "Target": df["yhat"]})
+        prophet_pred = prophet_pred.set_index("Date")
+        return prophet_pred["Target"].values


### PR DESCRIPTION
The Box-Cox generates a parameter `lambda` during training that needs to be passed to the forecasting stage so that the correct inverse can be applied. I've done this as `self.lam` but there might be a cleaner interface for it; I am very inexperienced with OO programming
    
I'm really sorry, but I have hardly tested this code at all because I'm a bit short on time. I know you wanted something this week so I thought I'd better commit and pull request now rather than when I've got everything 100% working